### PR TITLE
Fix

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -8,9 +8,9 @@ class OrdersController < ApplicationController
 	end
 
 	def index
-		@orders = @member.orders
+		# @orders = @member.orders
 		# 注文一覧を降順で表示する
-		@orders = Order.all.order("id DESC").page(params[:page]).per(10)
+		@orders = @member.orders.all.order("id DESC").page(params[:page]).per(10)
 	end
 
 	def show


### PR DESCRIPTION
ログインしている会員に関わらず、すべての注文履歴が表示されていたので、会員idに紐ずいた注文履歴が表示されるように修正しました。